### PR TITLE
Fixed typo which causes Exception

### DIFF
--- a/Classes/Hfrahmann/ConsoleLogging/Logger.php
+++ b/Classes/Hfrahmann/ConsoleLogging/Logger.php
@@ -149,7 +149,7 @@ class Logger {
                 if($collapsed === TRUE)
                     \ChromePhp::groupCollapsed($label);
                 else
-                    \ChromePHP::group($label);
+                    \ChromePhp::group($label);
                 break;
         }
     }


### PR DESCRIPTION
Fixes #2 
Without this fix you get an Exception when you want to log to Chrome.